### PR TITLE
feat: add integration themes

### DIFF
--- a/scalar-doc/src/lib.rs
+++ b/scalar-doc/src/lib.rs
@@ -20,6 +20,8 @@ pub enum Theme {
     Kepler,
     Mars,
     DeepSpace,
+    Elysiajs,
+    Fastify,
     None,
 }
 
@@ -45,6 +47,8 @@ impl Theme {
             Theme::Kepler => "kepler",
             Theme::Mars => "mars",
             Theme::DeepSpace => "deep-space",
+            Theme::Elysiajs => "elysiajs",
+            Theme::Fastify => "fastify",
             Theme::None => "none",
         }
     }


### PR DESCRIPTION
Hi! First of all, thanks for this crate. I really like Scalar and this crate made the integration simpler. 

A few months ago, Scalar added two new themes to their configuration: `"elysiajs"` and `"fastify"`. These themes were initially used for integration with the ElysiaJS and Fastify frameworks but are now available as standalone theme IDs.

This PR adds these new themes to the `Theme` enum and maps the new values to their matching theme IDs on Scalar.